### PR TITLE
[FIX] Fixes issue where old implementation code kept JHAudio address …

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -848,17 +848,6 @@ def calculate_shipping(rate_name, address, awc_session, quotation, save=True):
 	elif "shipping_method" in awc_session:
 		del awc_session["shipping_method"]
 
-	if rate_name == "PICK UP":
-		hq_address = frappe.get_value("AWC Settings", "AWC Settings", "shipping_address")
-		#address = frappe.get_doc("Address", hq_address).as_dict()
-		if quotation and quotation.shipping_address_name:
-			awc_session["last_shipping_address_name"] = quotation.shipping_address_name
-
-		quotation.shipping_address_name = hq_address
-	else:
-		if quotation and awc_session.get("last_shipping_address_name"):
-			quotation.shipping_address_name = awc_session["last_shipping_address_name"]
-
 	shipping_address_name = None
 
 	if quotation:


### PR DESCRIPTION
…around during tax calculation when selecting PICK UP option causing discrepancy on what custmer paid in taxes vs what was actually due.

Here is how to trigger the issue before this fix:

1) Pick any item(accessories are easier to do the math with)
2) Go to checkout, look at your tax
3) Pick a shipping address
4) By default you would get the first shipping option autoselected, so now select “PICK UP”
5) Taxes change due to shipping value being $0.00 but internally we use the JHaudio address as per the original requirements(Then later they wanted to keep the customer address and not see theirs… here is where the issues is)
6) Checkout either via paypal or credit card
7) Once the SO is created, the actual shipping address selected gets set and a second call to taxjar, shipping is till $0.00 but this time the call has a different zipcode/state so taxes change

So the issue is caused by remnant code from the original implementation….
My current fix is to remove the bit that sets the jhaudio address momentarily before the actual address is places, no idea how I kept this there originally.

However, there is a second minor issue. Is it ok to charge tax based on the shipping address of the customer even when they select the pick up option? I am guess this is ok.