### PR TITLE
Adds check for custom role 'Bill Me Later User'

### DIFF
--- a/awesome_cart/awesome_cart/doctype/credit_gateway_settings/credit_gateway_settings.py
+++ b/awesome_cart/awesome_cart/doctype/credit_gateway_settings/credit_gateway_settings.py
@@ -94,7 +94,9 @@ class CreditGatewaySettings(Document):
 			#return context["total_credit"] > 0
 			self.get_embed_context(context)
 
-			return customer.get("allow_billme_later", False)
+			# test for either allow_billme_later or can_billme_later role
+
+			return customer.get("allow_billme_later", False) or "Bill Me Later User" in frappe.get_roles()
 
 		return False
 


### PR DESCRIPTION
To test add the role:

Bill Me Later User

and assign it to your self, you will always be able to use bill me later even if "bill me later" checkbox isn't checked on any customer.