### PR TITLE
Move TaxJar API call before Shipment Management

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -1346,11 +1346,11 @@ def get_shipping_rate(address):
 	return result
 
 def update_shipping_rate(address, awc_session, is_pickup=False):
-	taxjar_api = frappe.get_hooks("taxjar_api") or []
+	tax_api = frappe.get_hooks("tax_api") or []
 	quotation = get_user_quotation(awc_session).get('doc')
 
 	if quotation:
-		for method in taxjar_api:
+		for method in tax_api:
 			frappe.call(method, quotation, None)
 
 	if address:

--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -1346,15 +1346,19 @@ def get_shipping_rate(address):
 	return result
 
 def update_shipping_rate(address, awc_session, is_pickup=False):
+	taxjar_api = frappe.get_hooks("taxjar_api") or []
+	quotation = get_user_quotation(awc_session).get('doc')
 
-	awc = awc_session.get("cart")
+	if quotation:
+		for method in taxjar_api:
+			frappe.call(method, quotation, None)
 
-	shipping_rate_api = frappe.get_hooks("shipping_rate_api")[0]
 	if address:
 		address_link = frappe.get_value("AWC Settings", "AWC Settings", "shipping_address")
 		from_address = frappe.get_doc("Address", address_link)
 
-	package_items=[]
+	package_items = []
+	awc = awc_session.get("cart")
 
 	if not is_pickup:
 		for item in awc["items"]:
@@ -1365,6 +1369,7 @@ def update_shipping_rate(address, awc_session, is_pickup=False):
 				}
 				package_items.append(package_item)
 
+	shipping_rate_api = frappe.get_hooks("shipping_rate_api")[0]
 	try:
 		if address and not is_pickup:
 			rates = frappe.call(shipping_rate_api["module"], from_address=from_address, to_address=address, items=package_items)
@@ -1379,7 +1384,6 @@ def update_shipping_rate(address, awc_session, is_pickup=False):
 	except Exception as ex:
 		log(traceback.format_exc())
 		rates = []
-
 
 	if address:
 		awc_session["last_shipping_address"] = address

--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -1346,12 +1346,12 @@ def get_shipping_rate(address):
 	return result
 
 def update_shipping_rate(address, awc_session, is_pickup=False):
-	tax_api = frappe.get_hooks("tax_api") or []
+	validation_hooks = frappe.get_hooks("awc_address_validation") or []
 	quotation = get_user_quotation(awc_session).get('doc')
 
 	if quotation:
-		for method in tax_api:
-			frappe.call(method, quotation, None)
+		for fn in validation_hooks:
+			frappe.call(fn, doc=quotation, address=address)
 
 	if address:
 		address_link = frappe.get_value("AWC Settings", "AWC Settings", "shipping_address")


### PR DESCRIPTION
Connected to https://github.com/DigiThinkIT/erpnext_taxjar/pull/14

---

If a wrong address is entered, TaxJar (or PyCountry) throws an error before a Shipment API call is made.

---

![image](https://user-images.githubusercontent.com/13396535/33882148-311de3a2-df5d-11e7-8d1a-b3985cb6a9d6.png)