### PR TITLE
Allows using urls to fetch awc templates instead of only doctype ones.

### DIFF
--- a/awesome_cart/public/js/client/awc.erpnext.adapter.js
+++ b/awesome_cart/public/js/client/awc.erpnext.adapter.js
@@ -222,7 +222,12 @@ awc.ErpnextAdapter.prototype._fetchProducts = function (filter, start, limit) {
 awc.ErpnextAdapter.prototype.loadTemplate = function (name) {
 	// simple template caching.  Always cache the promise
 	if (this._templates[name] === undefined) {
-		return this._templates[name] = awc.get('/awc_template/' + name).then(function (resp) {
+		var url = "/awc_template/" + name;
+		var file_asset_trigger = name.search(/^(\/|https?:\/\/)/i);
+		if ( file_asset_trigger > -1 ) {
+			url = name.substr(file_asset_trigger.index);
+		}
+		return this._templates[name] = awc.get(url).then(function (resp) {
 			return resp.body
 		});
 	} else {


### PR DESCRIPTION
I am allowing using absolute urls on awc templates to trigger fetching templates from urls instead of doctype names so we can move some templates back into repo. But right now it is used to load the social share feature on jhaudio3d