### PR TITLE
Adds fix to ignore pricing rule price resets on desk forms (Q, SO, SI)

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -607,11 +607,11 @@ def sync_awc_and_quotation(awc_session, quotation, quotation_is_dirty=False, sav
 					update_quotation_item_awc_fields(item, awc_item)
 
 					if awc_item.get("options", {}).get("custom", {}).get("rate", None) != None:
-						item.set("ignore_pricing_rule", 1)
+						item.set("item_ignore_pricing_rule", 1)
 						set_quotation_item_rate(item, awc_item["options"]["custom"]["rate"], product)
 					else:
 						set_quotation_item_rate(item, product.get("price"), product)
-						item.set("ignore_pricing_rule", 0)
+						item.set("item_ignore_pricing_rule", 0)
 
 					awc_items_matched.append(awc_item.get("id"))
 				else:
@@ -643,10 +643,10 @@ def sync_awc_and_quotation(awc_session, quotation, quotation_is_dirty=False, sav
 					new_quotation_item = quotation.append("items", item_data)
 
 					if awc_item.get("options", {}).get("custom", {}).get("rate", None) != None:
-						new_quotation_item.set("ignore_pricing_rule", 1)
+						new_quotation_item.set("item_ignore_pricing_rule", 1)
 						set_quotation_item_rate(new_quotation_item, awc_item["options"]["custom"]["rate"], product)
 					else:
-						new_quotation_item.set("ignore_pricing_rule", 0)
+						new_quotation_item.set("item_ignore_pricing_rule", 0)
 						set_quotation_item_rate(new_quotation_item, product.get("price"), product)
 
 					awc_item["unit"] = new_quotation_item.rate
@@ -729,20 +729,19 @@ def sync_awc_and_quotation(awc_session, quotation, quotation_is_dirty=False, sav
 
 	call_awc_sync_hook(awc_session, quotation)
 
-	if quotation_is_dirty:
-		update_cart_settings(quotation, awc_session)
-		quotation.flags.ignore_permissions = True
-		if save_quotation:
-			try:
-				quotation.save()
-				frappe.db.commit()
-			except Exception as ex:
-				log(traceback.format_exc())
-
-	collect_totals(quotation, awc, awc_session)
-
-	if awc_is_dirty:
-		set_awc_session(awc_session)
+	save_and_commit_quotation(quotation, quotation_is_dirty, awc_session, commit=False, save_session=awc_is_dirty)
+	# if quotation_is_dirty:
+	# 	update_cart_settings(quotation, awc_session)
+	# 	quotation.flags.ignore_permissions = True
+	# 	if save_quotation:
+	# 		try:
+	# 			quotation.save()
+	# 			frappe.db.commit()
+	# 		except Exception as ex:
+	# 			log(traceback.format_exc())
+	#collect_totals(quotation, awc, awc_session)
+	# if awc_is_dirty:
+	# 	set_awc_session(awc_session)
 
 	return quotation_is_dirty
 
@@ -965,7 +964,7 @@ def calculate_shipping(rate_name, address, awc_session, quotation, save=True, fo
 	shipping_address_name = None
 
 	if quotation:
-		update_cart_settings(quotation, awc_session)
+		#update_cart_settings(quotation, awc_session)
 
 		if address:
 			shipping_address_name = address.get("shipping_address")
@@ -1239,11 +1238,11 @@ def cart(data=None, action=None):
 				# TODO: ( >_<) shitty way of setting rate due to rate reset
 				#       Please fix when not utterly pissed off
 				if item.get("options", {}).get("custom", {}).get("rate", None) != None:
-					quotation_item.set("ignore_pricing_rule", 1)
+					quotation_item.set("item_ignore_pricing_rule", 1)
 					set_quotation_item_rate(quotation_item, item["options"]["custom"]["rate"], product)
 					item_data['total'] = item["options"]["custom"]["rate"] * cint(item.get("qty"))
 				else:
-					quotation_item.set("ignore_pricing_rule", 0)
+					quotation_item.set("item_ignore_pricing_rule", 0)
 					set_quotation_item_rate(quotation_item, product.get("price"), product)
 					item_data['total'] = product.get("price") * cint(item.get("qty"))
 
@@ -1268,7 +1267,7 @@ def cart(data=None, action=None):
 
 				quotation.set("items", quotation_items)
 
-			update_cart_settings(quotation, awc_session)
+			#update_cart_settings(quotation, awc_session)
 			quotation_is_dirty = True
 
 		save_and_commit_quotation(quotation, quotation_is_dirty, awc_session, commit=True)

--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -729,19 +729,7 @@ def sync_awc_and_quotation(awc_session, quotation, quotation_is_dirty=False, sav
 
 	call_awc_sync_hook(awc_session, quotation)
 
-	save_and_commit_quotation(quotation, quotation_is_dirty, awc_session, commit=False, save_session=awc_is_dirty)
-	# if quotation_is_dirty:
-	# 	update_cart_settings(quotation, awc_session)
-	# 	quotation.flags.ignore_permissions = True
-	# 	if save_quotation:
-	# 		try:
-	# 			quotation.save()
-	# 			frappe.db.commit()
-	# 		except Exception as ex:
-	# 			log(traceback.format_exc())
-	#collect_totals(quotation, awc, awc_session)
-	# if awc_is_dirty:
-	# 	set_awc_session(awc_session)
+	save_and_commit_quotation(quotation, quotation_is_dirty, awc_session, commit=True, save_session=awc_is_dirty)
 
 	return quotation_is_dirty
 
@@ -1267,7 +1255,6 @@ def cart(data=None, action=None):
 
 				quotation.set("items", quotation_items)
 
-			#update_cart_settings(quotation, awc_session)
 			quotation_is_dirty = True
 
 		save_and_commit_quotation(quotation, quotation_is_dirty, awc_session, commit=True)

--- a/awesome_cart/hooks.py
+++ b/awesome_cart/hooks.py
@@ -34,7 +34,8 @@ app_include_css = [
 app_include_js = [
 	"/assets/js/awc.ui.desk.js?v=%s" % app_version,
 	"/assets/js/awc_utils.js?v=%s" % app_version,
-	"/assets/js/credit_gateway_settings.js?v=%s" % app_version
+	"/assets/js/credit_gateway_settings.js?v=%s" % app_version,
+	"/assets/awesome_cart/js/desk_customizations/item_ignore_pricing_rule_patch.js?v=%s" % app_version
 ]
 
 website_route_rules = [
@@ -68,3 +69,5 @@ on_logout = "awesome_cart.utils.on_logout"
 awc_shipping_api = {
 	"get_rates": "awesome_cart.dummy.get_shipping_rates"
 }
+
+boot_session = "awesome_cart.utils.boot_session"

--- a/awesome_cart/public/js/desk_customizations/item_ignore_pricing_rule_patch.js
+++ b/awesome_cart/public/js/desk_customizations/item_ignore_pricing_rule_patch.js
@@ -1,0 +1,30 @@
+frappe.provide("awc");
+
+awc.ignore_pricing_rule_patch = {
+
+	rate: function(frm, cdt, cdn) {
+		// if user changes rate(deletes or sets) we always want to ignore rule as it is
+		// an explicit value set by the user.
+		frappe.model.set_value(cdt, cdn, "item_ignore_pricing_rule", 1);
+		frm.refresh()
+	},
+
+	discount_percentage: function(frm, cdt, cdn) {
+		var discount_percentage = frappe.model.get_value(cdt, cdn, "discount_percentage");
+		// when user deletes discount_percentage we get null, so lets remove the ignore price rule to allow
+		// default behaviour to take place
+		if ( discount_percentage == null ) {
+			frappe.model.set_value(cdt, cdn, "item_ignore_pricing_rule", 0);
+		} else {
+			// on a non null value passed set the ignore pricing rule as the user WANTED to
+			// modify the rate value reguardless of pricing rule.
+			frappe.model.set_value(cdt, cdn, "item_ignore_pricing_rule", 1);
+		}
+		frm.refresh();
+	}
+
+}
+
+frappe.ui.form.on('Quotation Item', awc.ignore_pricing_rule_patch);
+frappe.ui.form.on('Sales Order Item', awc.ignore_pricing_rule_patch);
+frappe.ui.form.on('Sales Invoice Item', awc.ignore_pricing_rule_patch);


### PR DESCRIPTION
There is a hidden deep behavior in ERPNext that I had no way of modifying without further spiraling into fixing other issues in the core.

This adds a temporary fix for our use case until we find a proper way to do it upstream.

So... Normally if a user changes the rate of an item where the parent doctype doesn't have a pricing rule. The rate and/or discount is respected when the **_AccountingController_** processes the items to set missing details.

However, if the user changes either rate or discount while there is a pricing rule applied, all edits are overwritten and there is no way to kept the user's entered values.

Due to the implementation between **_AccountController.set_missing_item_details_** and **_erpnext.stock.get_item_details.get_item_details_** when item's information is passed to the latter the parent's **_ignore_pricing_rule_** is copied temporarily to each item to process details and update the item's fields.

In this fix, during session boot we hot patch(which runs before loading any of the modules we are patching) **_erpnext.stock.get_item_details.get_item_details.get_item_details_** to modify the **_ignore_pricing_rule_** value with our own **_item_ignore_pricing_rule_** as to not cause a large change in how the codebase calculates prices but still be able to keep our custom rate/discount if the user sets it.

As a bonus, I've auto set **_item_ignore_pricing_rule_** to 1 or 0 depending if the user entered a value manually to rate/discount so they don't have to open the child table item every time they want to edit it during large order processing. Also, if they delete the discount percent(and not enter ANYTHING) it will set item_ignore_pricing_rule back to 0 automatically.

This change needs a new 'check' type custom field called **_item_ignore_pricing_rule_** on **_Quotation Item, Sales Order Item, Sales Invoice Item_** . I've created these in our clients repo:

https://github.com/DigiThinkIT/jhaudio_customizations/pull/975

The ideal way to fix this would be if the core code base we could tell if the user entered a rate/discount manually but I don't believe frappe keeps this information.