### PR TITLE
Hotfix billing address storing fix

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -1449,6 +1449,11 @@ def create_transaction(gateway_service, billing_address, shipping_address, instr
 		quotation.instructions = instructions
 		quotation_is_dirty = False
 
+	# set billilng address
+	if billing_address.get("billing_address") and quotation.customer_address != billing_address.get("billing_address"):
+		quotation.customer_address = billing_address.get("billing_address")
+		quotation_is_dirty = True
+
 	# make sure quotation email is contact person if we are a power user
 	quotation_is_dirty = sync_awc_and_quotation(awc_session, quotation, quotation_is_dirty, save_quotation=False)
 

--- a/awesome_cart/hooks.py
+++ b/awesome_cart/hooks.py
@@ -66,8 +66,12 @@ extend_website_page_controller_context = {
 #on_session_creation = "awesome_cart.utils.on_session_creation"
 on_logout = "awesome_cart.utils.on_logout"
 
+
 awc_shipping_api = {
 	"get_rates": "awesome_cart.dummy.get_shipping_rates"
 }
 
 boot_session = "awesome_cart.utils.boot_session"
+update_website_context = "awesome_cart.utils.run_hotpatch"
+on_session_creation = "awesome_cart.utils.run_hotpatch"
+on_login = "awesome_cart.utils.run_hotpatch"

--- a/awesome_cart/public/css/checkout.css
+++ b/awesome_cart/public/css/checkout.css
@@ -23,9 +23,9 @@
 	width: 60px;
 	height: 34px;
   }
-  
+
   .switch input {display:none;}
-  
+
   .slider {
 	position: absolute;
 	cursor: pointer;
@@ -37,7 +37,7 @@
 	-webkit-transition: .4s;
 	transition: .4s;
   }
-  
+
   .slider:before {
 	position: absolute;
 	content: "";
@@ -49,28 +49,40 @@
 	-webkit-transition: .4s;
 	transition: .4s;
   }
-  
+
   input:checked + .slider {
 	background-color: #000000;/*#2196F3;*/
   }
-  
+
   input:focus + .slider {
 	box-shadow: 0 0 1px #000000;/*#2196F3;*/
   }
-  
+
   input:checked + .slider:before {
 	-webkit-transform: translateX(26px);
 	-ms-transform: translateX(26px);
 	transform: translateX(26px);
   }
-  
+
   /* Rounded sliders */
   .slider.round {
 	border-radius: 34px;
   }
-  
+
   .slider.round:before {
 	border-radius: 50%;
   }
 
+
+.address-item .well {
+	padding: 0 !important;
+}
+
+.addr {
+	padding: .5em 1em;
+}
+
 /* Use customer Fedex toggle End */
+.awc-selected {
+	border: 2px solid black;
+}

--- a/awesome_cart/public/js/awc_utils.js
+++ b/awesome_cart/public/js/awc_utils.js
@@ -37,6 +37,7 @@ window.awc_utils = {
 
 		var tpl = awc_utils.render_address_widget(options);
 		var $widget = $(tpl);
+		$container.empty();
 		$container.append($widget);
 
 		$container.find(".addr").not(".no-click").click(function(e) {
@@ -71,6 +72,10 @@ window.awc_utils = {
 
 		if ( typeof options.on_init === "function" ) {
 			options.on_init($widget);
+		}
+
+		if ( options.default_address ) {
+			$container.find(".addr[data-name='" + options.default_address.replace("'", "\\'") + "']").click();
 		}
 
 	}

--- a/awesome_cart/utils.py
+++ b/awesome_cart/utils.py
@@ -70,6 +70,19 @@ def delete_address(address_name):
 def edit_address(address):
 	address =  json.loads(address)
 	add_doc = frappe.get_doc("Address", address.get('address_name'))
+	update_address(add_doc, address)
+
+@frappe.whitelist()
+def new_address(address):
+	address =  json.loads(address)
+	add_doc = frappe.new_doc("Address")
+	update_address(add_doc, address)
+
+	frappe.response.address_name = add_doc.name
+
+	return add_doc.as_dict()
+
+def update_address(add_doc, address):
 	add_doc.address_title = address.get('address_title')
 	add_doc.is_residential = address.get('address_is_residential')
 	add_doc.address_contact = address.get('address_contact')
@@ -83,6 +96,7 @@ def edit_address(address):
 	add_doc.flags.ignore_permissions=True
 	add_doc.save()
 	frappe.db.commit()
+
 
 def quotation_validate(doc, method):
 	main_items = []
@@ -190,10 +204,7 @@ def boot_session(bootinfo):
 
 def run_hotpatch(*args, **kwargs):
 	from erpnext.stock import get_item_details
-	print(" - RUNNING HOTPATCH...")
 
 	if not hasattr(get_item_details.process_args, "__patched"):
 		print(" - Patched: erpnext.stock.get_item_details.process_args -> awesome_cart.utils.erpnext_stock_get_item_details")
 		get_item_details.process_args = fn_wrap(get_item_details.process_args, erpnext_stock_get_item_details)
-	else:
-		print(" - Patch already applied...")


### PR DESCRIPTION
First pass at cleaning up billing and shipping form to uncobble our mess.

Fixes storing new billing address and now assigns the address before calling gateway redirections.

To see new behavior:

- Go to the billing section
- Click Add New Address
- Enter a new Address
- The result should look as it did before, you get redirected to confirm billing info
- If you go back to billing, the new address is added to the top of the list and you can clearly see it selected
- Also, billing form is cleared and ready for use again.

This needs to be thoroughly tested before going into production.
The Affirm bug this is related to has a separate pull request: https://github.com/DigiThinkIT/erpnext_affirm/pull/7

![awc-billing-form-fix](https://user-images.githubusercontent.com/1656249/37636888-07a79cb4-2bdb-11e8-95a3-8cb4256bc853.gif)
