### PR TITLE
Order For Issues Fix

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -569,7 +569,7 @@ def sync_awc_and_quotation(awc_session, quotation, quotation_is_dirty=False, sav
 	# and allow the quotation to rebuild it as this means a system user updated the
 	# quotation on the backend while they had the cart open
 	if awc_session.get('timestamp') and timestamp(quotation.modified) > awc_session.get('timestamp'):
-		clear_awc_session(awc_session)
+		clear_awc_session(awc_session, cart_only=True)
 
 	# step 1
 	# iterate over all awc items and update quotation to match values

--- a/awesome_cart/power.py
+++ b/awesome_cart/power.py
@@ -4,6 +4,7 @@ import traceback
 import frappe
 
 from .session import get_awc_session, set_awc_session
+from .utils import clear_cache
 from .dbug import pretty_json
 
 def get_user_contacts(user):
@@ -94,6 +95,7 @@ def set_cart_customer(customer_name):
 		if not contacts or len(contacts) == 0:
 			return "This Customer requires at least one Contact before placing an order!"
 
+		clear_cache()
 		awc_session = get_awc_session()
 		awc_session["selected_customer"] = customer_name
 		set_awc_session(awc_session)

--- a/awesome_cart/session.py
+++ b/awesome_cart/session.py
@@ -15,14 +15,17 @@ def get_awc_session():
 		awc_sid = "awc_session_{0}".format(sid)
 	awc_session = None
 
-	pretty_json(awc_session)
-
 	# lets make sure IPs match before applying this sid
 	if sid != None:
 		awc_session = frappe.cache().get_value(awc_sid)
 		if awc_session:
 			if awc_session.get("session_ip") != frappe.local.request_ip:
 				# IP do not match... force build session from scratch
+				log(" - AWC Session IP ADDRESS MISTMATCH {0} != {1} ... Resetting\n{0}".format(
+					awc_session.get("session_ip"),
+					frappe.local.request_ip,
+					pretty_json(awc_session)))
+
 				sid = None
 				awc_sid = None
 				awc_session = None
@@ -59,22 +62,25 @@ def set_awc_session(session):
 	frappe.cache().set_value("awc_session_{0}".format(frappe.local.session["awc_sid"]), session)
 	return session
 
-def clear_awc_session(awc_session=None):
+def clear_awc_session(awc_session=None, cart_only=False):
 	if not awc_session:
 		awc_session = get_awc_session()
 
-	if awc_session.get("shipping_method"):
-		del awc_session["shipping_method"]
-	if awc_session.get("shipping_rates"):
-		del awc_session["shipping_rates"]
-	if awc_session.get("shipping_rates_list"):
-		del awc_session["shipping_rates_list"]
-	if awc_session.get("selected_customer"):
-		del awc_session["selected_customer"]
-	if awc_session.get("selected_customer_image"):
-		del awc_session["selected_customer_image"]
+	if not cart_only:
+		if awc_session.get("shipping_method"):
+			del awc_session["shipping_method"]
+		if awc_session.get("shipping_rates"):
+			del awc_session["shipping_rates"]
+		if awc_session.get("shipping_rates_list"):
+			del awc_session["shipping_rates_list"]
+		if awc_session.get("selected_customer"):
+			del awc_session["selected_customer"]
+		if awc_session.get("selected_customer_image"):
+			del awc_session["selected_customer_image"]
+
 	if awc_session.get("timestamp"):
 		del awc_session["timestamp"]
+
 	awc_session["cart"] = { "items": [], "totals": { "sub_total": 0, "grand_total": 0, "other": [] } }
 
 def hash_key(key, prefix=''):

--- a/awesome_cart/session.py
+++ b/awesome_cart/session.py
@@ -21,7 +21,7 @@ def get_awc_session():
 		if awc_session:
 			if awc_session.get("session_ip") != frappe.local.request_ip:
 				# IP do not match... force build session from scratch
-				log(" - AWC Session IP ADDRESS MISTMATCH {0} != {1} ... Resetting\n{0}".format(
+				log(" - AWC Session IP ADDRESS MISTMATCH {0} != {1} ... Resetting\n{2}".format(
 					awc_session.get("session_ip"),
 					frappe.local.request_ip,
 					pretty_json(awc_session)))


### PR DESCRIPTION
Noticed that for power_user/order_for functionality a session clear would happen for quotations saved outside of the cart removing the customer selection.

This issue was introduced on PR: https://github.com/DigiThinkIT/awesome_cart/pull/264

Also, noticed that when switching between customers, product pricing cache did not clear showing the wrong prices if the last two customers had different pricing rules applied. This fixes that too.