### PR TITLE
Adds a global page body trigger to make power user settings and quotation information available to other scripts.

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -546,6 +546,12 @@ def sync_awc_and_quotation(awc_session, quotation, quotation_is_dirty=False, sav
 	# convert quotation to awc object
 	# and merge items in the case where items are added before logging in.
 
+	# Adding quotation information to session data to cache information on subsequent calls
+	awc_session["quotation_info"] = {
+		"quotation": quotation.name,
+		"customer": quotation.customer_name
+	}
+
 	# steps:
 	# 1) loop over all awc items and update quotation items matching names/ids
 	# 2) remove invalid awc items who's skus do not match any products(awc items)

--- a/awesome_cart/power.py
+++ b/awesome_cart/power.py
@@ -39,6 +39,7 @@ def get_power_user_settings():
 		return "Not A Power User"
 
 	user_doc = frappe.get_doc("User", frappe.session.user)
+	frappe.local.response["session_quotation"] = get_awc_session().get("quotation_info", {})
 
 	if user_doc.get("is_power_user")  or \
 		has_role([

--- a/awesome_cart/public/js/client/awc.erpnext.adapter.js
+++ b/awesome_cart/public/js/client/awc.erpnext.adapter.js
@@ -949,6 +949,7 @@ $(function () {
 	awc.call("awesome_cart.power.get_power_user_settings")
 		.then(function (resp) {
 			var data = resp.data;
+
 			if (data.message == "Power User") {
 				var cwindow_tpl = cart.template("Power User - Customer Select Window").promiseReady();
 				var $cwindow = null;
@@ -1007,6 +1008,9 @@ $(function () {
 					});
 				}
 			}
+
+			// triggers global page event to provide power user info to other scripts.
+			$("body").trigger("awc-power-user-settings", data);
 
 			return resp;
 		})


### PR DESCRIPTION
 - added an "awc-poweruser-settings" event with the format:

```json
{ 
   "customers": [
    {
      "customer_name": "<customer name id>",
      "label": "<customer name as it should be displayed>",
      "image": "<customer thumbnail image url>"
    }
  ],
  "message": "Power User" or "Not a Power User",
  "selected_customer": "<customer name selected as power user or null if none>",
  "selected_customer_image": "<customer thumbnail image>",
  "session_quotation": {
    "customer": "<customer name as it appears on quotation",
    "quotation": "<quotation name id>"
  }
}
```

Kept sushant's session quotation field names so his code in jhaudio_customizations doesn't break.

You can get this data by subscribing to body:

```javascript
$('body').on('awc-power-user-settings', (e, data) => {
  // all data
  console.log('power user data: ', data);

  // just quotation info
  console.log('session_quotation', data.session_quotation);
});
```