### PR TITLE
Fixes issue where billing editing could change shipping address after selection

### DIFF
--- a/awesome_cart/public/js/awc_cart.js
+++ b/awesome_cart/public/js/awc_cart.js
@@ -197,6 +197,26 @@ awc_checkout = {
 			},
 
 			on_edit_click: function($addr, e) {
+
+				// lets figure out if this address is being used on shipping
+				// if so, we'll need to insert this edit instead of saving to
+				// avoid changing the shipping address and shipping method.
+				// so, we'll invoke the new address form instead prefilled with
+				// this address values.
+				if (awc_checkout.shipping_provider.data && $addr.attr("data-name") == awc_checkout.shipping_provider.data.shipping_address) {
+					awc_checkout.displayAddNewBillingAddress({
+						title: $addr.find('span#title').text(),
+						phone: $addr.find('span#phone').text(),
+						line1: $addr.find('span#line1').text(),
+						line2: $addr.find('span#line2').text(),
+						city: $addr.find('span#city').text(),
+						state: $addr.find('span#state').text(),
+						pincode: $addr.find('span#pincode').text(),
+						country: $addr.find('span#country').text()
+					});
+					return;
+				}
+
 				$("#gateway-selector-billing-form").trigger("reset")
 				$('#gateway-selector-billing-form.awc-form')
 					.attr('data-name', $addr.attr('data-name'));
@@ -314,13 +334,7 @@ awc_checkout = {
 
 		// add new billing address button
 		$billing_container.find(".btn-primary").click(function(e) {
-			$('#checkout-billing .addr').removeClass('awc-selected');
-			$('#form-bill-addr').attr('data-select', 'true');
-			$("#gateway-selector-billing-form.awc-form").trigger("reset");
-			$('#gateway-selector-billing-form.awc-form .field.required input').change();
-			$('#gateway-selector-billing-form.awc-form .field.required select').change();
-			$('#select-bill-addr').css('display', 'none');
-			$('#form-bill-addr').css('display', 'block');
+			displayAddNewBillingAddress();
 		});
 
 		// billing form back button click
@@ -332,6 +346,28 @@ awc_checkout = {
 			$('#form-bill-addr').css('display', 'none');
 		});
 
+	},
+
+	/**
+	 * Displays the "Add new billing address" form
+	 * @arg data - An address is object formart to preset before displaying the form.
+	 */
+	displayAddNewBillingAddress: function(data) {
+		$('#checkout-billing .addr').removeClass('awc-selected');
+		$('#form-bill-addr').attr('data-select', 'true');
+		$("#gateway-selector-billing-form.awc-form").trigger("reset");
+		if ( data ) {
+			for(var key in data) {
+				var value = data[key];
+				if ( typeof(value) != 'function' ) {
+					$('#billing_' + key).val(value);
+				}
+			}
+		}
+		$('#gateway-selector-billing-form.awc-form .field.required input').change();
+		$('#gateway-selector-billing-form.awc-form .field.required select').change();
+		$('#select-bill-addr').css('display', 'none');
+		$('#form-bill-addr').css('display', 'block');
 	},
 
 	setupPage: function() {


### PR DESCRIPTION
When an address is used in both shipping and billing a user was allowed to edit the billing address. This caused the shipping address to become invalid in relation to the shipping method already selected.

This fix simply redirects the "edit" functionality to the new address form on the billing section of checkout while prefilling the address into the form. This allows the (confused)user to edit their billing address without making the shipping address invalid and inserts it as a new address.

![awc-billing-hotfix](https://user-images.githubusercontent.com/1656249/40443669-0f550d56-5e95-11e8-890e-d34dbee2c571.gif)
