### PR TITLE
Fix: Fixes sync hook not called due to caching issues.

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -896,8 +896,6 @@ def sync_awc_and_quotation(awc_session, quotation, quotation_is_dirty=False, sav
 				if msg:
 					msg = msg.format(coupon_code=quotation.coupon_code)
 					frappe.response["awc_alert"] = msg
-					# Q: This isn't showing up on front end... why?
-					# frappe.msgprint(msg, title="Message", alert=1)
 
 				if "coupon_total" in awc["totals"]:
 					del awc["totals"]["coupon_total"]

--- a/awesome_cart/power.py
+++ b/awesome_cart/power.py
@@ -112,6 +112,7 @@ def set_cart_customer(customer_name):
 
 		clear_cache()
 		awc_session = get_awc_session()
+		clear_awc_session(awc_session)
 		awc_session["selected_customer"] = customer_name
 		set_awc_session(awc_session)
 

--- a/awesome_cart/session.py
+++ b/awesome_cart/session.py
@@ -81,7 +81,13 @@ def clear_awc_session(awc_session=None, cart_only=False):
 	if awc_session.get("timestamp"):
 		del awc_session["timestamp"]
 
-	awc_session["cart"] = { "items": [], "discounts": None, "totals": { "sub_total": 0, "grand_total": 0, "other": [] } }
+	if not awc_session.get("cart"):
+		awc_session["cart"] = { "items": [], "discounts": None, "totals": { "sub_total": 0, "grand_total": 0, "other": [] } }
+	else:
+		# clean up without dropping cart item references
+		del awc_session["cart"]["items"][:]
+		awc_session["cart"]["discounts"] = None
+		awc_session["totals"] = { "sub_total": 0, "grand_total": 0, "other": [] }
 
 def hash_key(key, prefix=''):
 	if prefix:


### PR DESCRIPTION
Cache clearing was dropping cart item reference causing multiple calls to sync but never saving results, and setting the last timestamp causing sync hook result to be ignored(this is where jhaudio3d updates the edit_link to make iem editable)

Also added a session clear when switching power users to properly clear session when switching customers.