### PR TITLE
Fix error when trying to apply coupon code without selecting a shipping method

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -1547,7 +1547,7 @@ def cart(data=None, action=None):
 			is_valid = frappe.response.get("is_coupon_valid")
 
 			if is_valid:
-				shipping_method = awc_session.get("shipping_method", {}).get("name") or quotation.get("fedex_shipping_method", "").upper()
+				shipping_method = awc_session.get("shipping_method", {}).get("name") or (quotation.get("fedex_shipping_method") or "").upper()
 				discount, msg, apply_discount_on, coupon_state, has_services, has_total_limit = calculate_coupon_discount({
 					"items": quotation.items,
 					"code": coupon,
@@ -1565,7 +1565,7 @@ def cart(data=None, action=None):
 						msg = "Coupon is invalid for the current cart."
 				else:
 					awc["discounts"] = coupon_state
-					
+
 					insert_items = frappe.response.get("coupon_insert_items", False)
 
 					if insert_items:

--- a/awesome_cart/taxes_and_totals.py
+++ b/awesome_cart/taxes_and_totals.py
@@ -27,7 +27,7 @@ class AWCCalculateTaxesAndTotals(calculate_taxes_and_totals):
 
         # Apply coupon codes
         if self.doc.coupon_code:
-            shipping_method = awc_session.get("shipping_method", {}).get("name") or self.doc.get("fedex_shipping_method", "").upper()
+            shipping_method = awc_session.get("shipping_method", {}).get("name") or (self.doc.get("fedex_shipping_method") or "").upper()
             discount, msg, apply_discount_on, coupon_state, has_services, has_total_limit = calculate_coupon_discount({
                 "items": self.doc.items,
                 "code": self.doc.coupon_code,


### PR DESCRIPTION
@forellana-digithinkit, this is a tempfix for the Sentry errors.

It's happening because there is no shipping method selected when the user applies the coupon. Not sure if that should be allowed, but you'll have to look into it.

