### PR TITLE
fix: variants which have show_varient_in_website flag off cause base price miscalculation

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -314,7 +314,7 @@ def get_product_by_sku(sku, detailed=0, awc_session=None, quotation=None, skip_r
 	price_info = get_price(item.item_code, price_list)
 	price = price_info.get("rate")
 
-	variants = frappe.get_all("Item", fields=["name", "item_code"], filters={"variant_of": item.name, "disabled": 0})
+	variants = frappe.get_all("Item", fields=["name", "item_code"], filters={"variant_of": item.name, "disabled": 0, "show_variant_in_website": 1})
 	for vitem in variants:
 		vprice = get_price(vitem.get("item_code"), price_list).get("rate")
 		if vprice < price:
@@ -524,7 +524,7 @@ def fetch_products(tags="", terms="", order_by="order_weight", order_dir="asc", 
 			price_info = get_price(item.get("item_code"), price_list)
 			price = price_info.get("rate")
 
-			variants = frappe.get_all("Item", fields=["name", "item_code"], filters={"variant_of": item.get("name"), "disabled": 0})
+			variants = frappe.get_all("Item", fields=["name", "item_code"], filters={"variant_of": item.get("name"), "disabled": 0, "show_variant_in_website": 1})
 			for vitem in variants:
 				vprice = get_price(vitem.get("item_code"), price_list).get("rate")
 				if vprice < price:


### PR DESCRIPTION
This fixes issue report with 2-pin cable showing a discount... when there is no discount...

https://jhaudio.com/p/spare-iem-cable

From this:
![jha-invalid-discount 0](https://user-images.githubusercontent.com/1656249/54715202-3d8e7780-4b29-11e9-810e-6f01c2ce926c.png)

To this:
![jha-invalid-discount-fixed 0](https://user-images.githubusercontent.com/1656249/54715209-42532b80-4b29-11e9-94fb-c2007fdf1ad3.png)

Issue was caused because a hidden 18" variant(hidden on purpose, they don't want to sell to the general public) was included in the lowes price calculation but never appeared on the frontend.