### PR TITLE
fix: Fixes cart editing not calling hooks to update item customizations

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -1231,6 +1231,7 @@ def save_and_commit_quotation(quotation, is_dirty, awc_session, commit=False, sa
 			result = (False, ex)
 
 	collect_totals(quotation, None, awc_session)
+	call_awc_sync_hook(awc_session, quotation)
 
 	if save_session:
 		if quotation and len(awc_session.get('cart', {}).get('items', [])) > 0:

--- a/awesome_cart/public/awc-templates/full-cart.html
+++ b/awesome_cart/public/awc-templates/full-cart.html
@@ -52,9 +52,9 @@
         <div class="col-xs-9 col-sm-10 no-pad subgroup-name"></div>
       </div>
       {{#items}}
-      <div class="row col-xs-12 subgroup-item pad0" data-id="{{ this.id }}">
+      <div class="row col-xs-12 subgroup-item" data-id="{{ this.id }}">
         <div class="col-sm-2 hidden-xs no-pad"></div>
-        <div class="col-xs-5 no-pad"><span class="product-title">{{ this.product.name }}</span>
+        <div class="col-xs-5 no-pad title-col"><span class="product-title">{{ this.product.name }}</span>
 					{{#if options.display}}
 					{{#each options.display}}
 					<div class="{{class}} extra-data"><span class="label">{{label}}</span><span class="value">{{value}}</span></div>


### PR DESCRIPTION
Fixes issue where customization on cart items disappear due to sync hook not being called before saving cart data.