### PR TITLE
fix: avoid race conditions after payment success

### DIFF
--- a/awesome_cart/awesome_cart/doctype/awc_transaction/awc_transaction.py
+++ b/awesome_cart/awesome_cart/doctype/awc_transaction/awc_transaction.py
@@ -127,6 +127,8 @@ class AWCTransaction(Document):
 			call_hook("awc_transaction_after_on_sales_order_created", transaction=self, order=so)
 
 			if self.flags.get("skip_payment_request", False):
+				# avoid TimeStampMismatchError from hook events
+				so.reload()
 				so.submit()
 
 				self.reference_doctype = "Sales Order"


### PR DESCRIPTION
Found this while testing Affirm. Just after the payment was successful, it would try and submit the SO, which already had changes from certain hook events.

Reloading the doc, so that it has the new information.