### PR TITLE
fix: set ship address for pick up orders to calculate taxes

### DIFF
--- a/awesome_cart/awc.py
+++ b/awesome_cart/awc.py
@@ -1189,9 +1189,10 @@ def calculate_shipping(rate_name, address, awc_session, quotation, save=True, fo
 	is_pickup = False
 	if rate_name == "PICK UP":
 		if quotation:
-			quotation.shipping_address_name = ""
-			quotation.shipping_address = ""
-			save=True
+			shipping_address_name = frappe.db.get_single_value("Awc Settings", "shipping_address")
+			quotation.shipping_address_name = shipping_address_name
+			quotation.shipping_address = get_address_display(shipping_address_name)
+			save = True
 
 		force = True
 		is_pickup = True


### PR DESCRIPTION
Based on reports from Shelley about Pick Up orders not displaying taxes to the customer before they're paid for.

@forellana-digithinkit, I wasn't able to replicate the issue locally - the taxes were coming up properly on the cart as soon as I clicked on Pick Up (this was for a new customer with no addresses).

I'm still creating a draft PR just in case you want to test force-set of the address from AWC Settings.